### PR TITLE
Feature/kan 38 velocity controlled drivetrain

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/MecanumDrive.java
@@ -44,6 +44,11 @@ public class MecanumDrive extends LinearOpMode {
                 robotHardware.drivetrain.toggleFieldCentricDrive();
             }
 
+            // Toggle whether or not the robot will drive using velocity.
+            if (currentGamepad.start && !previousGamepad.start) {
+                robotHardware.drivetrain.toggleVelocityDrive();
+            }
+
             // Drive the robot based on user inputs.
             robotHardware.drivetrain.driveRobotWithControllerInputs(currentGamepad.left_stick_x,
                     currentGamepad.left_stick_y, currentGamepad.right_stick_x);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utility/Constants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utility/Constants.java
@@ -2,7 +2,11 @@ package org.firstinspires.ftc.teamcode.Utility;
 
 public final class Constants {
 
-    public final class DrivetrainConstants {
+    public static final class DrivetrainConstants {
+
+        // Store the maximum possible speeds that the drive motors can turn at.
+        public static final double MAX_MOTOR_ANGULAR_VELOCITY_RADIANS_PER_SECOND = 36.6519142919;
+        public static final double MAX_MOTOR_POWER = 1;
 
         // The robot's x velocity will be multiplied by this value. Doing this helps counteract
         // imperfect straifing.


### PR DESCRIPTION
This feature should make it possible to drive the robot using velocities instead of motor powers. This offers several benefits such as being able to drive at a consistent speed regardless of battery levels, greater control during auto, and more.

Additionally, the maximum motor power has been changed to a variable in constants to make maintenance easier.

Several methods have been added to the `Drivetrain` class for the new velocity drive:
- `toggleVelocityDrive()`
- `toggleVelocityDrive(boolean enabled)`
- `getVelocityDriveEnabled()`

New Controls:
- Start: Toggles velocity drive.

BREAKING CHANGES:
- Renamed `boolean fieldCentric` to `boolean fieldCentricEnabled`
- Renamed `setFieldCentricDrive(boolean fieldCentricDrive)` to `toggleFieldCentricDrive(boolean enabled)`
- Renamed `getFieldCentricState()` to `getFieldCentricEnabled()`